### PR TITLE
Generate docker image with PHP-7.4.28 and grpc-1.44.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN set -eux \
   #  && apt-get install -y php7.4-mbstring \
    && docker-php-ext-install zip
 
-RUN pecl install grpc
+RUN pecl install grpc-1.44.0
 RUN pecl install protobuf
 
 RUN set -ex; \


### PR DESCRIPTION
Per https://github.com/googleapis/google-cloud-php/issues/5164, the setup demands a `grpc` version to be `1.44.0` but the latest version is well past that and currently stands at `1.45.0`.

This is a placeholder PR to showcase and generate Docker image: [vishwaraj00/php-7.4-apache-grpc-protobuf](https://hub.docker.com/repository/docker/vishwaraj00/php-7.4-apache-grpc-protobuf) with PHP-7.4.28 because the base image `php:7.4-apache` has patch version `28`.

> Note: This PR has already been used as per the README to generate the 7.4 docker image.
